### PR TITLE
Add dependency for potionGlintType

### DIFF
--- a/src/main/java/cc/woverflow/glintcolorizer/config/GlintConfig.java
+++ b/src/main/java/cc/woverflow/glintcolorizer/config/GlintConfig.java
@@ -47,6 +47,8 @@ public class GlintConfig extends Config {
     public GlintConfig() {
         super(new Mod(GlintColorizer.NAME, ModType.UTIL_QOL, new VigilanceMigrator(new File(GlintColorizer.modDir, GlintColorizer.ID + ".toml").getPath())), GlintColorizer.ID + ".json");
         initialize();
+
+        addDependency("potionGlintType", "potionGlint");
     }
 }
 //#endif


### PR DESCRIPTION
Now the option will only be active when Shiny Pots is enabled.